### PR TITLE
Limit pug bombs to a maximum of 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "hubot-google-translate": "^0.2.0",
     "hubot-help": "^0.2.0",
     "hubot-maps": "0.0.2",
-    "hubot-pugme": "^0.1.0",
+    "hubot-pugme": "tarebyte/hubot-pugme#tarebyte/limit-pugs",
     "hubot-redis-brain": "0.0.3",
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.17.2",


### PR DESCRIPTION
In the spirit of not driving everyone crazy by doing something like `hubot pug bomb 9001`. We're going to limit the number of pugs in a pug bomb to a max of 5.

/cc @Shy as the requester.